### PR TITLE
Enhance semantic release configuration with build command and changelog settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,26 @@ indent-width = 4
 
 [tool.semantic_release]
 version_toml = ["pyproject.toml:project.version"]
+build_command = """
+    python -m pip install build
+    python -m build --wheel --sdist
+"""
 branch = "main"
 upload_to_pypi = false
 changelog_file = "CHANGELOG.md"
+
+[tool.semantic_release.changelog]
+exclude_commit_patterns = [
+  '''chore(?:\([^)]*?\))?: .+''',
+  '''ci(?:\([^)]*?\))?: .+''',
+  '''refactor(?:\([^)]*?\))?: .+''',
+  '''style(?:\([^)]*?\))?: .+''',
+  '''test(?:\([^)]*?\))?: .+''',
+  '''build\((?!deps\): .+)''',
+  '''Merged? .*''',
+  '''Initial Commit.*''',
+  # Old semantic-release version commits
+  '''^\d+\.\d+\.\d+''',
+]
+insertion_flag = "=========\nCHANGELOG\n========="
+mode = "update"


### PR DESCRIPTION
Improve the semantic release setup by adding a build command and refining changelog settings to exclude specific commit patterns.